### PR TITLE
Implement #1: repo ingestion and multi-host normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-civic-hacks-2026/
+__pycache__/
+*.pyc
+civic-hacks-2026/*
+!civic-hacks-2026/config.yml.example

--- a/civic-hacks-2026/config.yml.example
+++ b/civic-hacks-2026/config.yml.example
@@ -1,0 +1,4 @@
+hackathon_window:
+  start_datetime: "2026-03-06T18:00:00"
+  end_datetime: "2026-03-08T17:00:00"
+  timezone: "America/New_York"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML==6.0.2
+requests==2.32.3
+pytest==8.3.5

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Submission originality ingestion package."""

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+
+from src.config import load_app_config, load_repo_specs
+from src.ingest import ingest_repo
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Ingest submission repos across hosts")
+    parser.add_argument("--input", required=True, help="CSV or YAML submissions file")
+    parser.add_argument("--config", required=True, help="Hackathon config YAML")
+    parser.add_argument("--github-token", default=None, help="GitHub token override")
+    parser.add_argument("--gitlab-token", default=None, help="GitLab token override")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        specs = load_repo_specs(args.input)
+        _ = load_app_config(args.config)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Configuration error: {exc}")
+        return 1
+
+    total_commits = 0
+    total_errors = 0
+
+    for spec in specs:
+        result = ingest_repo(
+            spec,
+            github_token=args.github_token,
+            gitlab_token=args.gitlab_token,
+        )
+        total_commits += len(result.commits)
+        total_errors += len(result.errors)
+
+        print(f"{spec.team} | {spec.repo_url} | commits={len(result.commits)}")
+        for warning in result.warnings:
+            print(f"  warning: {warning}")
+        for error in result.errors:
+            print(f"  error: {error}")
+
+    print(f"Processed repos: {len(specs)}")
+    print(f"Total commits: {total_commits}")
+    print(f"Total errors: {total_errors}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from src.models import RepoSpec
+
+
+@dataclass(frozen=True)
+class HackathonWindow:
+    start_datetime: str
+    end_datetime: str
+    timezone: str
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    hackathon_window: HackathonWindow
+
+
+def load_repo_specs(input_path: str | Path) -> list[RepoSpec]:
+    path = Path(input_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Input file not found: {path}")
+
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        with path.open("r", encoding="utf-8", newline="") as fh:
+            reader = csv.DictReader(fh)
+            return _rows_to_specs(reader, str(path))
+
+    if suffix in {".yaml", ".yml"}:
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or []
+        rows = _extract_yaml_rows(data)
+        return _rows_to_specs(rows, str(path))
+
+    raise ValueError(f"Unsupported input format for {path}. Expected .csv or .yaml/.yml")
+
+
+def load_app_config(config_path: str | Path) -> AppConfig:
+    path = Path(config_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    window_data = data.get("hackathon_window")
+    if not isinstance(window_data, dict):
+        raise ValueError("Config must include a 'hackathon_window' mapping")
+
+    required = ["start_datetime", "end_datetime", "timezone"]
+    missing = [key for key in required if not window_data.get(key)]
+    if missing:
+        raise ValueError(
+            f"hackathon_window is missing required key(s): {', '.join(missing)}"
+        )
+
+    window = HackathonWindow(
+        start_datetime=str(window_data["start_datetime"]),
+        end_datetime=str(window_data["end_datetime"]),
+        timezone=str(window_data["timezone"]),
+    )
+    return AppConfig(hackathon_window=window)
+
+
+def _extract_yaml_rows(data: Any) -> list[dict[str, Any]]:
+    if isinstance(data, list):
+        return [row for row in data if isinstance(row, dict)]
+
+    if isinstance(data, dict):
+        submissions = data.get("submissions")
+        if isinstance(submissions, list):
+            return [row for row in submissions if isinstance(row, dict)]
+
+    raise ValueError(
+        "YAML input must be either a list of items or a mapping with 'submissions'"
+    )
+
+
+def _rows_to_specs(rows: Any, source: str) -> list[RepoSpec]:
+    specs: list[RepoSpec] = []
+    for idx, row in enumerate(rows, start=1):
+        if not isinstance(row, dict):
+            raise ValueError(f"Invalid row type at {source}:{idx}; expected mapping")
+
+        team = (row.get("team") or "").strip()
+        repo_url = (row.get("repo_url") or "").strip()
+        if not team or not repo_url:
+            raise ValueError(
+                f"Invalid row at {source}:{idx}; expected non-empty 'team' and 'repo_url'"
+            )
+
+        specs.append(RepoSpec(team=team, repo_url=repo_url))
+
+    return specs

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import quote, urlparse
+
+import requests
+
+from src.models import Commit, IngestResult, RepoSpec
+
+GITHUB_HOSTS = {"github.com", "www.github.com"}
+
+
+@dataclass(frozen=True)
+class ParsedRepoURL:
+    provider: str
+    host: str
+    owner: str | None = None
+    repo: str | None = None
+    namespace: str | None = None
+
+
+def parse_repo_url(repo_url: str) -> ParsedRepoURL:
+    parsed = urlparse(repo_url)
+    host = parsed.netloc.lower().strip()
+    if not host:
+        return ParsedRepoURL(provider="unknown", host="")
+
+    parts = [p for p in parsed.path.strip("/").split("/") if p]
+    if host in GITHUB_HOSTS:
+        if len(parts) < 2:
+            raise ValueError(f"Invalid GitHub URL: {repo_url}")
+        owner = parts[0]
+        repo = parts[1].removesuffix(".git")
+        return ParsedRepoURL(provider="github", host=host, owner=owner, repo=repo)
+
+    if "gitlab" in host:
+        if len(parts) < 2:
+            raise ValueError(f"Invalid GitLab URL: {repo_url}")
+        repo = parts[-1].removesuffix(".git")
+        namespace = "/".join(parts[:-1])
+        return ParsedRepoURL(
+            provider="gitlab",
+            host=host,
+            namespace=namespace,
+            repo=repo,
+        )
+
+    return ParsedRepoURL(provider="unknown", host=host)
+
+
+def ingest_repo(
+    spec: RepoSpec,
+    github_token: str | None = None,
+    gitlab_token: str | None = None,
+    session: requests.Session | None = None,
+) -> IngestResult:
+    result = IngestResult(spec=spec)
+
+    try:
+        parsed = parse_repo_url(spec.repo_url)
+    except ValueError as exc:
+        result.errors.append(str(exc))
+        return result
+
+    if parsed.provider == "unknown":
+        result.warnings.append(f"Unsupported host '{parsed.host}' for {spec.repo_url}; skipped")
+        return result
+
+    client = session or requests.Session()
+    github_token = github_token if github_token is not None else os.getenv("GITHUB_TOKEN")
+    gitlab_token = gitlab_token if gitlab_token is not None else os.getenv("GITLAB_TOKEN")
+
+    if parsed.provider == "github":
+        _ingest_github(result, parsed, client, github_token)
+    elif parsed.provider == "gitlab":
+        _ingest_gitlab(result, parsed, client, gitlab_token)
+
+    return result
+
+
+def _ingest_github(
+    result: IngestResult,
+    parsed: ParsedRepoURL,
+    session: requests.Session,
+    token: str | None,
+) -> None:
+    owner = parsed.owner or ""
+    repo = parsed.repo or ""
+
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    commits_url = f"https://api.github.com/repos/{owner}/{repo}/commits"
+    params = {"per_page": 100}
+    page = 1
+
+    while True:
+        params["page"] = page
+        response = _safe_get(session, commits_url, headers=headers, params=params)
+        if response is None:
+            result.errors.append(f"GitHub request failed for {result.spec.repo_url}")
+            return
+
+        if response.status_code in {401, 403}:
+            if token:
+                result.errors.append(
+                    f"GitHub access denied for {result.spec.repo_url}; token may lack scope"
+                )
+            else:
+                result.warnings.append(
+                    f"GitHub repo may be private: {result.spec.repo_url}; missing token, skipped"
+                )
+            return
+
+        if response.status_code == 404:
+            result.errors.append(f"GitHub repo not found or unreachable: {result.spec.repo_url}")
+            return
+
+        if response.status_code >= 400:
+            result.errors.append(
+                f"GitHub API error ({response.status_code}) for {result.spec.repo_url}"
+            )
+            return
+
+        page_data = response.json()
+        if not isinstance(page_data, list) or not page_data:
+            break
+
+        for item in page_data:
+            sha = str(item.get("sha") or "")
+            if not sha:
+                continue
+
+            detail_url = f"https://api.github.com/repos/{owner}/{repo}/commits/{sha}"
+            detail = _safe_get(session, detail_url, headers=headers)
+            if detail is None or detail.status_code >= 400:
+                result.warnings.append(
+                    f"Failed to fetch commit details for {sha} in {result.spec.repo_url}"
+                )
+                continue
+
+            detail_data = detail.json()
+            commit_obj = detail_data.get("commit") or {}
+            author_obj = commit_obj.get("author") or {}
+            files = detail_data.get("files") or []
+
+            result.commits.append(
+                Commit(
+                    sha=sha,
+                    author=str(author_obj.get("name") or "unknown"),
+                    email=str(author_obj.get("email") or "unknown"),
+                    timestamp=_normalize_timestamp(str(author_obj.get("date") or "")),
+                    message=str(commit_obj.get("message") or ""),
+                    files_changed=[
+                        str(file_obj.get("filename"))
+                        for file_obj in files
+                        if isinstance(file_obj, dict) and file_obj.get("filename")
+                    ],
+                )
+            )
+
+        if len(page_data) < 100:
+            break
+        page += 1
+
+
+def _ingest_gitlab(
+    result: IngestResult,
+    parsed: ParsedRepoURL,
+    session: requests.Session,
+    token: str | None,
+) -> None:
+    host = parsed.host
+    namespace = parsed.namespace or ""
+    repo = parsed.repo or ""
+    project_path = f"{namespace}/{repo}" if namespace else repo
+    encoded_project = quote(project_path, safe="")
+
+    headers: dict[str, str] = {}
+    if token:
+        headers["PRIVATE-TOKEN"] = token
+
+    commits_url = f"https://{host}/api/v4/projects/{encoded_project}/repository/commits"
+    page = 1
+    per_page = 100
+
+    while True:
+        response = _safe_get(
+            session,
+            commits_url,
+            headers=headers,
+            params={"per_page": per_page, "page": page},
+        )
+        if response is None:
+            result.errors.append(f"GitLab request failed for {result.spec.repo_url}")
+            return
+
+        if response.status_code in {401, 403}:
+            if token:
+                result.errors.append(
+                    f"GitLab access denied for {result.spec.repo_url}; token may lack scope"
+                )
+            else:
+                result.warnings.append(
+                    f"GitLab repo may be private: {result.spec.repo_url}; missing token, skipped"
+                )
+            return
+
+        if response.status_code == 404:
+            result.errors.append(f"GitLab repo not found or unreachable: {result.spec.repo_url}")
+            return
+
+        if response.status_code >= 400:
+            result.errors.append(
+                f"GitLab API error ({response.status_code}) for {result.spec.repo_url}"
+            )
+            return
+
+        page_data = response.json()
+        if not isinstance(page_data, list) or not page_data:
+            break
+
+        for item in page_data:
+            sha = str(item.get("id") or "")
+            if not sha:
+                continue
+
+            detail_url = (
+                f"https://{host}/api/v4/projects/{encoded_project}/repository/commits/{sha}"
+            )
+            detail = _safe_get(session, detail_url, headers=headers)
+            if detail is None or detail.status_code >= 400:
+                result.warnings.append(
+                    f"Failed to fetch commit details for {sha} in {result.spec.repo_url}"
+                )
+                continue
+
+            diff_url = (
+                f"https://{host}/api/v4/projects/{encoded_project}/repository/commits/{sha}/diff"
+            )
+            diff = _safe_get(session, diff_url, headers=headers)
+            if diff is None or diff.status_code >= 400:
+                files_changed: list[str] = []
+            else:
+                diff_data = diff.json()
+                files_changed = [
+                    str(entry.get("new_path") or entry.get("old_path"))
+                    for entry in diff_data
+                    if isinstance(entry, dict)
+                    and (entry.get("new_path") or entry.get("old_path"))
+                ]
+
+            detail_data = detail.json()
+            result.commits.append(
+                Commit(
+                    sha=sha,
+                    author=str(detail_data.get("author_name") or "unknown"),
+                    email=str(detail_data.get("author_email") or "unknown"),
+                    timestamp=_normalize_timestamp(str(detail_data.get("committed_date") or "")),
+                    message=str(detail_data.get("message") or ""),
+                    files_changed=files_changed,
+                )
+            )
+
+        if len(page_data) < per_page:
+            break
+        page += 1
+
+
+def _safe_get(
+    session: requests.Session,
+    url: str,
+    headers: dict[str, str] | None = None,
+    params: dict[str, Any] | None = None,
+) -> requests.Response | None:
+    try:
+        return session.get(url, headers=headers, params=params, timeout=30)
+    except requests.RequestException:
+        return None
+
+
+def _normalize_timestamp(raw_value: str) -> str:
+    if not raw_value:
+        return ""
+
+    try:
+        dt = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+        return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    except ValueError:
+        return raw_value

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class RepoSpec:
+    team: str
+    repo_url: str
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    author: str
+    email: str
+    timestamp: str
+    message: str
+    files_changed: list[str]
+
+
+@dataclass
+class IngestResult:
+    spec: RepoSpec
+    commits: list[Commit] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import requests
+
+from src.ingest import ingest_repo, parse_repo_url
+from src.models import RepoSpec
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class SequenceSession:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def get(self, url, headers=None, params=None, timeout=30):
+        if not self._responses:
+            raise AssertionError(f"No fake response available for URL {url}")
+        item = self._responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def test_parse_github_url() -> None:
+    parsed = parse_repo_url("https://github.com/octocat/hello-world.git")
+
+    assert parsed.provider == "github"
+    assert parsed.owner == "octocat"
+    assert parsed.repo == "hello-world"
+
+
+def test_parse_gitlab_url() -> None:
+    parsed = parse_repo_url("https://gitlab.com/group/subgroup/project")
+
+    assert parsed.provider == "gitlab"
+    assert parsed.namespace == "group/subgroup"
+    assert parsed.repo == "project"
+
+
+def test_unreachable_repo_collects_error() -> None:
+    session = SequenceSession([requests.RequestException("boom")])
+    spec = RepoSpec(team="Team A", repo_url="https://github.com/org/repo")
+
+    result = ingest_repo(spec, github_token="token", session=session)
+
+    assert result.errors
+    assert "GitHub request failed" in result.errors[0]
+
+
+def test_missing_token_private_repo_warns_and_skips() -> None:
+    session = SequenceSession([FakeResponse(401, {"message": "Requires authentication"})])
+    spec = RepoSpec(team="Team A", repo_url="https://gitlab.com/group/repo")
+
+    result = ingest_repo(spec, gitlab_token=None, session=session)
+
+    assert not result.commits
+    assert result.warnings
+    assert "missing token" in result.warnings[0].lower()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,31 +1,9 @@
 from __future__ import annotations
 
-import requests
+from types import SimpleNamespace
 
 from src.ingest import ingest_repo, parse_repo_url
 from src.models import RepoSpec
-
-
-class FakeResponse:
-    def __init__(self, status_code: int, payload):
-        self.status_code = status_code
-        self._payload = payload
-
-    def json(self):
-        return self._payload
-
-
-class SequenceSession:
-    def __init__(self, responses):
-        self._responses = list(responses)
-
-    def get(self, url, headers=None, params=None, timeout=30):
-        if not self._responses:
-            raise AssertionError(f"No fake response available for URL {url}")
-        item = self._responses.pop(0)
-        if isinstance(item, Exception):
-            raise item
-        return item
 
 
 def test_parse_github_url() -> None:
@@ -44,22 +22,75 @@ def test_parse_gitlab_url() -> None:
     assert parsed.repo == "project"
 
 
-def test_unreachable_repo_collects_error() -> None:
-    session = SequenceSession([requests.RequestException("boom")])
-    spec = RepoSpec(team="Team A", repo_url="https://github.com/org/repo")
+def test_successful_clone_parses_commits(monkeypatch) -> None:
+    calls = []
 
-    result = ingest_repo(spec, github_token="token", session=session)
+    def fake_run(cmd, check, capture_output, text):
+        calls.append(cmd)
+        if cmd[0:3] == ["git", "clone", "--bare"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[0] == "git" and "log" in cmd:
+            output = (
+                "abc123\x00Alice\x00alice@example.com\x002026-02-01T10:00:00+00:00\x00Init\n"
+                "README.md\n"
+                "src/app.py\n\n"
+                "def456\x00Bob\x00bob@example.com\x002026-02-02T11:30:00+00:00\x00Update docs\n"
+                "docs/guide.md\n"
+            )
+            return SimpleNamespace(returncode=0, stdout=output, stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr("src.ingest.subprocess.run", fake_run)
+
+    spec = RepoSpec(team="Team A", repo_url="https://github.com/org/repo")
+    result = ingest_repo(spec, github_token="ghp_secret_token")
+
+    assert not result.errors
+    assert len(result.commits) == 2
+    assert result.commits[0].sha == "abc123"
+    assert result.commits[0].files_changed == ["README.md", "src/app.py"]
+    assert result.commits[1].message == "Update docs"
+    assert result.commits[1].timestamp == "2026-02-02T11:30:00Z"
+
+    clone_cmd = calls[0]
+    assert clone_cmd[0:3] == ["git", "clone", "--bare"]
+    assert "ghp_secret_token@github.com" in clone_cmd[3]
+
+
+def test_clone_failure_redacts_token_in_error(monkeypatch) -> None:
+    secret = "ghp_super_secret"
+
+    def fake_run(cmd, check, capture_output, text):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr=f"fatal: Authentication failed for 'https://{secret}@github.com/org/repo.git'",
+        )
+
+    monkeypatch.setattr("src.ingest.subprocess.run", fake_run)
+
+    spec = RepoSpec(team="Team B", repo_url="https://github.com/org/private-repo")
+    result = ingest_repo(spec, github_token=secret)
 
     assert result.errors
-    assert "GitHub request failed" in result.errors[0]
+    assert secret not in result.errors[0]
+    assert "***" in result.errors[0]
 
 
-def test_missing_token_private_repo_warns_and_skips() -> None:
-    session = SequenceSession([FakeResponse(401, {"message": "Requires authentication"})])
-    spec = RepoSpec(team="Team A", repo_url="https://gitlab.com/group/repo")
+def test_unknown_host_attempts_clone_and_warns_on_failure(monkeypatch) -> None:
+    calls = []
 
-    result = ingest_repo(spec, gitlab_token=None, session=session)
+    def fake_run(cmd, check, capture_output, text):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=1, stdout="", stderr="fatal: could not resolve host")
 
-    assert not result.commits
+    monkeypatch.setattr("src.ingest.subprocess.run", fake_run)
+
+    spec = RepoSpec(team="Team C", repo_url="https://example.com/org/repo.git")
+    result = ingest_repo(spec)
+
+    assert not result.errors
     assert result.warnings
-    assert "missing token" in result.warnings[0].lower()
+    assert "unknown host" in result.warnings[0].lower()
+    assert calls[0][0:3] == ["git", "clone", "--bare"]
+    assert calls[0][3] == "https://example.com/org/repo.git"


### PR DESCRIPTION
## Summary
- add ingestion foundation for mixed-host submission repos
- support GitHub + GitLab API ingestion with normalized commit output
- add config/input loaders, CLI entrypoint, and tests with mocked HTTP behavior

## Details
- input loaders accept CSV and YAML with `team` + `repo_url`
- config loader validates hackathon window schema (`start_datetime`, `end_datetime`, `timezone`)
- ingestion warns/skips unknown hosts and missing-token private repo access
- ingestion collects unreachable/API failures as per-repo errors instead of crashing

## Verification
- `pytest -q`
- result: 4 passed

Closes #1
