### PR TITLE
Implement per-team report generation (#5)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from src.config import load_app_config, load_repo_specs
+from src.devpost import load_submissions
 from src.ingest import ingest_repo
+from src.report import analyze_genai_optional, build_team_report, write_reports
 from src.temporal import analyze_repo
 
 
@@ -17,6 +20,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--analyze",
         action="store_true",
         help="Run temporal originality analysis after ingestion",
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Run ingest + analysis pipeline and write team markdown reports",
     )
     return parser
 
@@ -34,6 +42,8 @@ def main() -> int:
 
     total_commits = 0
     total_errors = 0
+    reports = []
+    submission_map = _load_submission_map(args.input)
 
     for spec in specs:
         result = ingest_repo(
@@ -43,33 +53,91 @@ def main() -> int:
         )
         total_commits += len(result.commits)
         total_errors += len(result.errors)
+        temporal_report = analyze_repo(result, app_config.hackathon_window) if args.report or args.analyze else None
 
         print(f"{spec.team} | {spec.repo_url} | commits={len(result.commits)}")
-        if args.analyze:
-            report = analyze_repo(result, app_config.hackathon_window)
-            largest_pre = len(report.largest_pre_commit.files_changed) if report.largest_pre_commit else 0
+        if temporal_report and args.analyze:
+            largest_pre = (
+                len(temporal_report.largest_pre_commit.files_changed)
+                if temporal_report.largest_pre_commit
+                else 0
+            )
             first_in_window = (
-                report.first_in_window_commit.timestamp if report.first_in_window_commit else "none"
+                temporal_report.first_in_window_commit.timestamp
+                if temporal_report.first_in_window_commit
+                else "none"
             )
             print(
                 "  analysis: "
-                f"pre={report.pre_window} "
-                f"in={report.in_window} "
-                f"post={report.post_window} "
-                f"pre_pct={report.pre_window_pct:.1f}% "
+                f"pre={temporal_report.pre_window} "
+                f"in={temporal_report.in_window} "
+                f"post={temporal_report.post_window} "
+                f"pre_pct={temporal_report.pre_window_pct:.1f}% "
                 f"largest_pre_files={largest_pre} "
                 f"first_in_window={first_in_window} "
-                f"risk={report.risk_flag} ({report.risk_reason})"
+                f"risk={temporal_report.risk_flag} ({temporal_report.risk_reason})"
             )
+
+        if args.report:
+            genai_report, genai_warning = analyze_genai_optional(result)
+            if genai_warning:
+                print(f"  warning: {genai_warning}")
+
+            submission = _find_submission_for_spec(
+                spec.team,
+                spec.repo_url,
+                submission_map,
+            )
+            reports.append(
+                build_team_report(
+                    spec=spec,
+                    ingest_result=result,
+                    temporal=temporal_report,
+                    genai=genai_report,
+                    submission=submission,
+                )
+            )
+
         for warning in result.warnings:
             print(f"  warning: {warning}")
         for error in result.errors:
             print(f"  error: {error}")
 
+    if args.report:
+        output_dir = Path("civic-hacks-2026") / "reports"
+        written = write_reports(output_dir, reports)
+        print(f"Wrote {len(written)} report files to {output_dir}")
+
     print(f"Processed repos: {len(specs)}")
     print(f"Total commits: {total_commits}")
     print(f"Total errors: {total_errors}")
     return 0
+
+
+def _load_submission_map(input_path: str) -> list:
+    try:
+        return load_submissions(input_path)
+    except (FileNotFoundError, ValueError):
+        return []
+
+
+def _normalize_repo_url(url: str) -> str:
+    normalized = (url or "").strip().lower()
+    return normalized.removesuffix(".git")
+
+
+def _find_submission_for_spec(team: str, repo_url: str, submissions: list):
+    normalized_repo = _normalize_repo_url(repo_url)
+    for submission in submissions:
+        for candidate in submission.repo_urls:
+            if _normalize_repo_url(candidate) == normalized_repo:
+                return submission
+
+    lowered_team = team.strip().lower()
+    for submission in submissions:
+        if submission.title.strip().lower() == lowered_team:
+            return submission
+    return None
 
 
 if __name__ == "__main__":

--- a/src/report.py
+++ b/src/report.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Literal
+
+from src.devpost import Submission
+from src.models import IngestResult, RepoSpec
+from src.temporal import TemporalReport
+
+if TYPE_CHECKING:
+    from src.genai_signals import GenAIReport
+
+Severity = Literal["clean", "review-recommended", "flagged"]
+
+
+@dataclass(frozen=True)
+class TeamReport:
+    team: str
+    repo_url: str
+    devpost_title: str | None
+    devpost_track: str | None
+    devpost_team_members: list[str]
+    temporal: TemporalReport | None
+    genai: GenAIReport | None
+    overall_flag: Severity
+    overall_reason: str
+
+
+def load_genai_analyzer() -> tuple[Callable[[IngestResult], Any] | None, str | None]:
+    try:
+        module = import_module("src.genai_signals")
+    except ModuleNotFoundError:
+        return None, "GenAI module unavailable; skipping GenAI signals section."
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        return None, f"Unable to load GenAI module; skipping GenAI signals section ({exc})."
+
+    analyze_repo = getattr(module, "analyze_repo", None)
+    if not callable(analyze_repo):
+        return None, "GenAI module missing analyze_repo; skipping GenAI signals section."
+
+    return analyze_repo, None
+
+
+def analyze_genai_optional(result: IngestResult) -> tuple[Any | None, str | None]:
+    analyzer, warning = load_genai_analyzer()
+    if analyzer is None:
+        return None, warning
+
+    try:
+        return analyzer(result), None
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        return None, f"GenAI analysis failed for {result.spec.repo_url}; skipped ({exc})"
+
+
+def build_team_report(
+    spec: RepoSpec,
+    ingest_result: IngestResult,
+    temporal: TemporalReport | None,
+    genai: Any | None,
+    submission: Submission | None,
+) -> TeamReport:
+    del ingest_result  # included for pipeline consistency and future enrichment
+
+    has_genai_only = bool(
+        genai
+        and getattr(genai, "genai_signals", [])
+        and not getattr(genai, "human_signals", [])
+    )
+
+    if temporal and temporal.risk_flag == "high":
+        overall_flag: Severity = "flagged"
+        overall_reason = (
+            f"Temporal originality risk is high: {temporal.risk_reason} "
+            "Recommend organizer review before judging."
+        )
+    elif (temporal and temporal.risk_flag == "medium") or has_genai_only:
+        overall_flag = "review-recommended"
+        reason_parts: list[str] = []
+        if temporal and temporal.risk_flag == "medium":
+            reason_parts.append(f"Temporal originality risk is medium: {temporal.risk_reason}")
+        if has_genai_only:
+            reason_parts.append(
+                "GenAI usage signals were detected with limited human engagement indicators"
+            )
+        overall_reason = "; ".join(reason_parts) + "."
+    else:
+        overall_flag = "clean"
+        overall_reason = "No major originality concerns were detected from available signals."
+
+    members = submission.team_members if submission else []
+
+    return TeamReport(
+        team=spec.team,
+        repo_url=spec.repo_url,
+        devpost_title=submission.title if submission else None,
+        devpost_track=submission.track if submission else None,
+        devpost_team_members=members,
+        temporal=temporal,
+        genai=genai,
+        overall_flag=overall_flag,
+        overall_reason=overall_reason,
+    )
+
+
+def render_team_report(report: TeamReport) -> str:
+    devpost_title = report.devpost_title or "Not provided"
+    devpost_track = report.devpost_track or "Not provided"
+    members = ", ".join(report.devpost_team_members) if report.devpost_team_members else "Not provided"
+
+    lines = [
+        f"# {report.team} - {report.overall_flag.upper()}",
+        "",
+        f"**Repo:** {report.repo_url}",
+        f"**Devpost:** {devpost_title} | Track: {devpost_track}",
+        f"**Team members:** {members}",
+        "",
+        "## Temporal Originality",
+    ]
+
+    if report.temporal is None:
+        lines.append("Temporal analysis was not available for this repository.")
+    else:
+        lines.extend(
+            [
+                f"- Commits analyzed: {report.temporal.total_commits}",
+                (
+                    "- Commit timing: "
+                    f"pre-window={report.temporal.pre_window}, "
+                    f"in-window={report.temporal.in_window}, "
+                    f"post-window={report.temporal.post_window}"
+                ),
+                f"- Pre-window percentage: {report.temporal.pre_window_pct:.1f}%",
+                f"- Risk flag: {report.temporal.risk_flag}",
+                f"- Reason: {report.temporal.risk_reason}",
+            ]
+        )
+
+    lines.extend(["", "## GenAI Signals"])
+
+    genai_signals = list(getattr(report.genai, "genai_signals", [])) if report.genai else []
+    if genai_signals:
+        for signal in genai_signals:
+            lines.append(f"- {signal.name}: {signal.description}")
+    else:
+        lines.append("None detected.")
+
+    lines.extend(["", "## Human Engagement"])
+
+    human_signals = list(getattr(report.genai, "human_signals", [])) if report.genai else []
+    if human_signals:
+        for signal in human_signals:
+            lines.append(f"- {signal.name}: {signal.description}")
+    else:
+        lines.append("None detected.")
+
+    lines.extend(["", "## Summary", report.overall_reason, ""])
+    return "\n".join(lines)
+
+
+def render_index(reports: list[TeamReport]) -> str:
+    severity_rank = {"flagged": 0, "review-recommended": 1, "clean": 2}
+    ordered = sorted(
+        reports,
+        key=lambda report: (severity_rank.get(report.overall_flag, 99), report.team.lower()),
+    )
+
+    lines = [
+        "# Submission Originality Summary",
+        "",
+        "| Team | Flag | Temporal Risk | Pre-window % | GenAI Signals |",
+        "|---|---|---|---:|---:|",
+    ]
+
+    for report in ordered:
+        temporal_risk = report.temporal.risk_flag if report.temporal else "n/a"
+        pre_window_pct = f"{report.temporal.pre_window_pct:.1f}%" if report.temporal else "n/a"
+        genai_count = len(getattr(report.genai, "genai_signals", [])) if report.genai else 0
+        lines.append(
+            "| "
+            f"{report.team} | {report.overall_flag} | {temporal_risk} | {pre_window_pct} | {genai_count} "
+            "|"
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_reports(output_dir: Path, reports: list[TeamReport]) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+
+    for report in reports:
+        slug = _slugify(report.team)
+        report_path = output_dir / f"{slug}.md"
+        report_path.write_text(render_team_report(report), encoding="utf-8")
+        written.append(report_path)
+
+    index_path = output_dir / "index.md"
+    index_path.write_text(render_index(reports), encoding="utf-8")
+    written.append(index_path)
+
+    return written
+
+
+def _slugify(value: str) -> str:
+    cleaned = "".join(ch.lower() if ch.isalnum() else "-" for ch in value.strip())
+    squashed = "-".join(part for part in cleaned.split("-") if part)
+    return squashed or "team-report"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from src.devpost import Submission
+from src.genai_signals import GenAIReport, GenAISignal
+from src.models import Commit, IngestResult, RepoSpec
+from src.report import (
+    analyze_genai_optional,
+    build_team_report,
+    load_genai_analyzer,
+    render_index,
+    render_team_report,
+)
+from src.temporal import TemporalReport
+
+
+def _spec(team: str = "Team One", repo_url: str = "https://github.com/org/repo") -> RepoSpec:
+    return RepoSpec(team=team, repo_url=repo_url)
+
+
+def _ingest(spec: RepoSpec | None = None) -> IngestResult:
+    return IngestResult(spec=spec or _spec())
+
+
+def _temporal(
+    risk_flag: str,
+    reason: str = "temporal reason",
+    pre_window_pct: float = 10.0,
+) -> TemporalReport:
+    return TemporalReport(
+        team="Team One",
+        repo_url="https://github.com/org/repo",
+        total_commits=10,
+        pre_window=1,
+        in_window=8,
+        post_window=1,
+        pre_window_pct=pre_window_pct,
+        largest_pre_commit=None,
+        first_in_window_commit=None,
+        risk_flag=risk_flag,
+        risk_reason=reason,
+    )
+
+
+def _genai(genai_count: int = 1, human_count: int = 0) -> GenAIReport:
+    genai_signals = [
+        GenAISignal(name=f"genai_{idx}", description="signal", commits=[f"g{idx}"])
+        for idx in range(genai_count)
+    ]
+    human_signals = [
+        GenAISignal(name=f"human_{idx}", description="signal", commits=[f"h{idx}"])
+        for idx in range(human_count)
+    ]
+    return GenAIReport(
+        team="Team One",
+        repo_url="https://github.com/org/repo",
+        genai_signals=genai_signals,
+        human_signals=human_signals,
+        summary="summary",
+    )
+
+
+def _submission() -> Submission:
+    return Submission(
+        title="Civic App",
+        description="desc",
+        track="Community",
+        team_members=["Alice", "Bob"],
+        repo_urls=["https://github.com/org/repo"],
+        submitted_at=None,
+        source="https://devpost.com/software/civic-app",
+    )
+
+
+def test_flagged_when_temporal_risk_is_high() -> None:
+    report = build_team_report(
+        spec=_spec(),
+        ingest_result=_ingest(),
+        temporal=_temporal("high", reason="60% pre-window"),
+        genai=None,
+        submission=_submission(),
+    )
+
+    assert report.overall_flag == "flagged"
+    assert "high" in report.overall_reason.lower()
+
+
+def test_review_recommended_when_temporal_risk_is_medium() -> None:
+    report = build_team_report(
+        spec=_spec(),
+        ingest_result=_ingest(),
+        temporal=_temporal("medium", reason="25% pre-window"),
+        genai=None,
+        submission=_submission(),
+    )
+
+    assert report.overall_flag == "review-recommended"
+
+
+def test_clean_when_no_signals() -> None:
+    report = build_team_report(
+        spec=_spec(),
+        ingest_result=_ingest(),
+        temporal=_temporal("low", reason="mostly in-window"),
+        genai=_genai(genai_count=0, human_count=0),
+        submission=_submission(),
+    )
+
+    assert report.overall_flag == "clean"
+
+
+def test_render_team_report_includes_expected_sections() -> None:
+    team_report = build_team_report(
+        spec=_spec(),
+        ingest_result=_ingest(),
+        temporal=_temporal("medium", reason="25% pre-window"),
+        genai=_genai(genai_count=1, human_count=1),
+        submission=_submission(),
+    )
+
+    markdown = render_team_report(team_report)
+
+    assert "# Team One - REVIEW-RECOMMENDED" in markdown
+    assert "## Temporal Originality" in markdown
+    assert "## GenAI Signals" in markdown
+    assert "## Human Engagement" in markdown
+    assert "## Summary" in markdown
+
+
+def test_render_index_sorts_flagged_first() -> None:
+    flagged = build_team_report(
+        spec=_spec(team="Zulu"),
+        ingest_result=_ingest(),
+        temporal=_temporal("high"),
+        genai=None,
+        submission=None,
+    )
+    clean = build_team_report(
+        spec=_spec(team="Alpha", repo_url="https://github.com/org/alpha"),
+        ingest_result=_ingest(_spec(team="Alpha", repo_url="https://github.com/org/alpha")),
+        temporal=_temporal("low"),
+        genai=None,
+        submission=None,
+    )
+
+    index_markdown = render_index([clean, flagged])
+
+    lines = [
+        line
+        for line in index_markdown.splitlines()
+        if line.startswith("| ") and "---" not in line and not line.startswith("| Team |")
+    ]
+    assert lines[0].startswith("| Zulu | flagged")
+    assert lines[1].startswith("| Alpha | clean")
+
+
+def test_missing_devpost_submission_is_handled() -> None:
+    report = build_team_report(
+        spec=_spec(),
+        ingest_result=_ingest(),
+        temporal=_temporal("low"),
+        genai=None,
+        submission=None,
+    )
+
+    assert report.devpost_title is None
+    assert report.devpost_track is None
+    assert report.devpost_team_members == []
+
+
+def test_missing_genai_module_handled_gracefully(monkeypatch) -> None:
+    def fake_import(name: str):
+        if name == "src.genai_signals":
+            raise ModuleNotFoundError("src.genai_signals")
+        raise AssertionError(f"unexpected module request: {name}")
+
+    monkeypatch.setattr("src.report.import_module", fake_import)
+
+    analyzer, warning = load_genai_analyzer()
+    assert analyzer is None
+    assert warning is not None
+
+    commit = Commit(
+        sha="abc",
+        author="Alice",
+        email="alice@example.com",
+        timestamp="2026-02-20T14:00:00Z",
+        message="init",
+        files_changed=["README.md"],
+    )
+    result = IngestResult(spec=_spec(), commits=[commit])
+    genai_report, warning2 = analyze_genai_optional(result)
+
+    assert genai_report is None
+    assert warning2 is not None


### PR DESCRIPTION
## Summary
- add new `src/report.py` module with `TeamReport`, `build_team_report`, `render_team_report`, and `render_index`
- derive `overall_flag` using temporal risk and GenAI-without-human-signal rule
- support optional GenAI module loading and graceful skip behavior when unavailable
- add CLI `--report` mode to run ingest + analysis pipeline and write:
  - `civic-hacks-2026/reports/<team-slug>.md`
  - `civic-hacks-2026/reports/index.md`
- add `tests/test_report.py` covering flag logic, markdown sections, index sorting, and graceful missing-data paths

## Verification
- `pytest -q` (27 passed)

Closes #5